### PR TITLE
Allow vagrant runner for different GH account/repo combis

### DIFF
--- a/ubuntu-vagrant/playbook.yml
+++ b/ubuntu-vagrant/playbook.yml
@@ -24,5 +24,6 @@
         name: monolithprojects.github_actions_runner
       vars:
         access_token: "{{ lookup('env','PAT') }}"
+        runner_dir: /opt/actions-runner/{{ github_account }}/{{ github_repo }}
       tags:
         - uninstall


### PR DESCRIPTION
Stolen with pride from https://github.com/ci-for-science/self-hosted-runners/blob/58b062d14755c2ba56d533dc7a06ee92f65c2a82/ubuntu-surf-hpc-cloud/runner/playbook.yml